### PR TITLE
[INFRA-7298] Automatically add the Cabot user and anyone @mentioned to the channel

### DIFF
--- a/cabot_alert_mattermost/models.py
+++ b/cabot_alert_mattermost/models.py
@@ -187,7 +187,7 @@ class MatterMostAlert(AlertPlugin):
         try:
             self._add_users_to_channel(url, headers, channel_id, users_to_add + [CABOT_USERNAME])
         except requests.HTTPError:
-            logger.exception('Failed to add users to the channel.')
+            logger.exception('Failed to add users to channel %s. Is the Cabot MM user an admin here?', channel_id)
 
         failing_checks = service.all_failing_checks()
 
@@ -203,7 +203,7 @@ class MatterMostAlert(AlertPlugin):
             file_ids = self._upload_files(url, headers, channel_id, files)
         except requests.HTTPError:
             # continue anyway, just don't put any images in the message
-            logger.exception('Failed to get/upload images.')
+            logger.exception('Failed to get/upload images to channel %s.', channel_id)
 
         # post in the channel
         response = requests.post(urljoin(url, 'posts'), headers=headers, json={

--- a/cabot_alert_mattermost/models.py
+++ b/cabot_alert_mattermost/models.py
@@ -138,14 +138,14 @@ class MatterMostAlert(AlertPlugin):
                             "Does the Cabot user have admin permissions in this channel?\n[%s] %s",
                             username, user_id, channel_id, response.status_code, response.text)
 
-    def _upload_files(self, url, headers, channel_id, files, timeout=30):
+    def _upload_files(self, url, headers, channel_id, files, timeout_seconds=30):
         """
         Upload a list of files to MM.
         :param url: MM api v4 endpoint
         :param headers: HTTP headers (w/ api token)
         :param channel_id: channel ID to add users to
         :param files: list of files as ('filename', data) tuples
-        :param timeout: timeout for uploading all files (default 30s)
+        :param timeout_seconds: timeout for uploading all files (default 30s)
         :return: list of MM file IDs
         """
         if len(files) == 0:
@@ -160,7 +160,7 @@ class MatterMostAlert(AlertPlugin):
             data={'channel_id': channel_id},
             files=files,
             headers=headers,
-            timeout=timeout,
+            timeout=timeout_seconds,
         )
         _check_response(response)
 
@@ -186,7 +186,7 @@ class MatterMostAlert(AlertPlugin):
         # if the Cabot user isn't in the channel, we won't be able to send the message
         try:
             self._add_users_to_channel(url, headers, channel_id, users_to_add + [CABOT_USERNAME])
-        except:
+        except requests.HTTPError:
             logger.exception('Failed to add users to the channel.')
 
         failing_checks = service.all_failing_checks()
@@ -201,7 +201,7 @@ class MatterMostAlert(AlertPlugin):
                     filename = '{}.png'.format(check.name)
                     files.append((filename, image))
             file_ids = self._upload_files(url, headers, channel_id, files)
-        except:
+        except requests.HTTPError:
             # continue anyway, just don't put any images in the message
             logger.exception('Failed to get/upload images.')
 

--- a/cabot_alert_mattermost/models.py
+++ b/cabot_alert_mattermost/models.py
@@ -77,113 +77,145 @@ def _check_response(response):
         raise requests.HTTPError(e.message + ', response body: ' + response.text, response=response)
 
 
+def _get_mm_api_for_service(service):
+    """
+    :param service: the service to pull from (to get MM instance, etc...)
+    :return: a tuple of (api_endpoint_url, http_headers, channel_id)
+    """
+    if service.mattermost_instance is not None:
+        server_url = service.mattermost_instance.server_url
+        api_token = service.mattermost_instance.api_token
+        channel_id = service.mattermost_instance.default_channel_id
+    else:
+        raise RuntimeError('Mattermost instance not set.')
+
+    if service.mattermost_channel_id:
+        channel_id = service.mattermost_channel_id
+    if not channel_id:
+        raise RuntimeError('Mattermost channel ID not set.')
+
+    api_url = urljoin(server_url, 'api/v4/')
+    headers = {
+        'Authorization': 'Bearer {}'.format(api_token),
+    }
+    return api_url, headers, channel_id
+
+
 class MatterMostAlert(AlertPlugin):
     name = "MatterMost"
     author = "Mahendra M"
 
-    def _send_alert(self, service, message, add_users=[]):
+    def _add_users_to_channel(self, url, headers, channel_id, users_to_add):
         """
-        Send an alert with the service status, failing
-        checks for a service and images to a Mattermost channel
-        :param service: the Service we're alerting for
-        :param message: the message to post
-        :param add_users: MM usernames to ensure are in the channel (so @mentions work)
-                          note that CABOT_USERNAME is automatically added to this list
-                          (i.e. Cabot will add itself to any channels it sends messages to)
+        Adds the given list of usernames to the given channel_id.
+        Silently continues if some usernames can't be found on MM. Logs a warning if a user is found, but can't be added
+        to the channel (e.g. if our bot doesn't have permissions for this channel).
+        :param url: MM api v4 endpoint
+        :param headers: HTTP headers (w/ api token)
+        :param channel_id: channel ID to add users to
+        :param users_to_add: list of usernames to add to the channel
         :return: None
         """
-        if service.mattermost_instance is not None:
-            url = service.mattermost_instance.server_url
-            api_token = service.mattermost_instance.api_token
-            channel_id = service.mattermost_instance.default_channel_id
-        else:
-            raise RuntimeError('Mattermost instance not set.')
-
-        if service.mattermost_channel_id:
-            channel_id = service.mattermost_channel_id
-        if not channel_id:
-            raise RuntimeError('Mattermost channel ID not set.')
-
-        url = urljoin(url, 'api/v4/')
-
-        # Headers for the data
-        headers = {
-            'Authorization': 'Bearer {}'.format(api_token),
-        }
-
-        # ensure listed users are in the channel (including the Cabot user)
-        # if this fails, we may not be able to send the message (if the Cabot user isn't already in the channel...)
+        if len(users_to_add) == 0:
+            return
 
         # first, map usernames -> user ids, since the channels API requires ids
         # note that any usernames that can't be found are just not included in the response
         # for example, ["i_dont_exist", "i_exist", ""] returns [{"username": "i_exist", "id": "123123", ...}]
-        response = requests.post(urljoin(url, 'users/usernames'), headers=headers, json=add_users + [CABOT_USERNAME])
-        if response.status_code == 200:
-            for user in response.json():
-                # can't find any bulk API for adding users to channel, so we do it one at a time
-                username = user['username']
-                user_id = user['id']
+        response = requests.post(urljoin(url, 'users/usernames'), headers=headers, json=users_to_add)
+        _check_response(response)
 
-                # if the user is already in the channel, this API call seems to just do nothing
-                response = requests.post(urljoin(url, 'channels/{}/members'.format(channel_id)),
-                                         headers=headers, json={'user_id': user_id})
-                if response.status_code != 201:
-                    logger.warn("Could not add user %s, id %s to channel id %s: [%s] %s",
-                                username, user_id, channel_id, response.status_code, response.text)
+        for user in response.json():
+            # can't find any bulk API for adding users to channel, so we do it one at a time
+            username = user['username']
+            user_id = user['id']
 
-        else:
-            logger.warn("Could not map usernames to user ids: [%s] %s", response.status_code, response.text)
+            # if the user is already in the channel, this API call seems to just do nothing
+            response = requests.post(urljoin(url, 'channels/{}/members'.format(channel_id)),
+                                     headers=headers, json={'user_id': user_id})
+            if response.status_code != 201:
+                logger.warn("Could not add user %s, id %s to channel id %s. "
+                            "Does the Cabot user have admin permissions in this channel?\n[%s] %s",
+                            username, user_id, channel_id, response.status_code, response.text)
+
+    def _upload_files(self, url, headers, channel_id, files, timeout=30):
+        """
+        Upload a list of files to MM.
+        :param url: MM api v4 endpoint
+        :param headers: HTTP headers (w/ api token)
+        :param channel_id: channel ID to add users to
+        :param files: list of files as ('filename', data) tuples
+        :param timeout: timeout for uploading all files (default 30s)
+        :return: list of MM file IDs
+        """
+        if len(files) == 0:
+            return []
+
+        # convert to a list of ('files', ('filename', <data>))
+        # (can't use dict form because we have multiple values for the 'files' key...)
+        files = [('files', (f[0], f[1])) for f in files]
+
+        response = requests.post(
+            urljoin(url, 'files'),
+            data={'channel_id': channel_id},
+            files=files,
+            headers=headers,
+            timeout=timeout,
+        )
+        _check_response(response)
+
+        file_ids = [x['id'] for x in response.json()['file_infos']]
+        if not len(file_ids) == len(files):
+            logger.warn('It seems some files failed to upload (server returned %s file IDs, but we sent %s): %s',
+                        len(file_ids), len(files), response.json())
+        return file_ids
+
+    def _send_alert(self, service, message, users_to_add=[]):
+        """
+        Send an alert with the service status, failing checks for a service and images to a Mattermost channel
+        :param service: the Service we're alerting for
+        :param message: the message to post
+        :param users_to_add: MM usernames to ensure are in the channel (so @mentions work)
+                             note that CABOT_USERNAME is automatically added to this list
+                             (i.e. Cabot will add itself to any channels it sends messages to)
+        :return: None
+        """
+        url, headers, channel_id = _get_mm_api_for_service(service)
+
+        # ensure users we're going to @mention are in the channel (including the Cabot user)
+        # if the Cabot user isn't in the channel, we won't be able to send the message
+        try:
+            self._add_users_to_channel(url, headers, channel_id, users_to_add + [CABOT_USERNAME])
+        except:
+            logger.exception('Failed to add users to the channel.')
 
         failing_checks = service.all_failing_checks()
 
         # Upload images for all failing checks
-        files = []
-        failing_checks_with_images = []
         file_ids = []
-        for check in failing_checks:
-            image = check.get_status_image()
-            if image is not None:
-                filename = '{}.png'.format(check.name)
-                files.append(('files', (filename, image)))
-                failing_checks_with_images.append(check)
+        try:
+            files = []
+            for check in failing_checks:
+                image = check.get_status_image()
+                if image is not None:
+                    filename = '{}.png'.format(check.name)
+                    files.append((filename, image))
+            file_ids = self._upload_files(url, headers, channel_id, files)
+        except:
+            # continue anyway, just don't put any images in the message
+            logger.exception('Failed to get/upload images.')
 
-        # Upload all the images, if any, in one shot
-        if len(files) > 0:
-            images_url = urljoin(url, 'files')
-
-            response = requests.post(
-                images_url,
-                data={'channel_id': channel_id},
-                files=files,
-                headers=headers,
-                timeout=30,
-            )
-
-            # Don't worry about images getting uploaded
-            if response.status_code == 201:
-                file_ids = [x['id'] for x in response.json()['file_infos']]
-                if not len(file_ids) == len(files):
-                    logger.warn('Seems some files failed to upload (server returned %s file IDs, but we sent %s): %s',
-                                len(file_ids), len(files), response.json())
-            else:
-                logger.warn('Images failed to upload, got status code %s: %s',
-                            response.status_code, response.json())
-
-        # build attachments
-        title = '{service} is {status}'.format(service=service.name, status=service.overall_status)
-        color = COLORS.get(service.overall_status)
-        attachments = [{
-            'fallback': title,  # this is the text that shows in notifications
-            'color': color,
-            'text': message,
-        }]
-
+        # post in the channel
         response = requests.post(urljoin(url, 'posts'), headers=headers, json={
             'channel_id': channel_id,
             'message': '',
             'file_ids': file_ids,
             'props': {
-                'attachments': attachments
+                'attachments': [{
+                    'fallback': '{} is {}'.format(service.name, service.overall_status),  # this shows in notifications
+                    'color': COLORS.get(service.overall_status),
+                    'text': message,
+                }]
             },
         })
         _check_response(response)


### PR DESCRIPTION
Cabot can only message channels that it's a member of, and @mentions only work if the user is already in the channel.

With this PR, Cabot will:

* Try to join the channel it's alerting to
  - it can do this automatically for public channels
  - it must be manually invited (by the channel admin) to any private channels
    + Otherwise the MM API will return 4xx and we log a warning
* Try to add anyone it @mentions to the channel
  - it can always do this in public channels
  - it can do this in private channels if it has been given the "Channel Admin" title by a channel admin
    + Otherwise the MM API will return 4xx and we log a warning

Currently working with IT to see if there is an admin role we can give Cabot that will make this "just work™" for private channels, but don't hold your breath.

Also include API responses in the logs on error, since MM has nice error messages.