### PR TITLE
Tests + support for 'acked' status

### DIFF
--- a/cabot_alert_mattermost/models.py
+++ b/cabot_alert_mattermost/models.py
@@ -24,6 +24,7 @@ EMOJIS = {
     'ERROR': ":sad-panda:",
     'CRITICAL': ":alert:",
     'PASSING': ":dancing-panda:",
+    'ACKED': ":zipper_mouth_face:",
 }
 
 COLORS = {
@@ -31,6 +32,7 @@ COLORS = {
     'ERROR': '#FF0000',
     'CRITICAL': '#FF0000',
     'PASSING': '#00FF00',
+    'ACKED': '#FC9300',
 }
 
 MESSAGE_TEMPLATE_NORMAL = '''
@@ -274,6 +276,12 @@ class MatterMostAlert(AlertPlugin):
             if old_status == service.WARNING_STATUS:
                 # Don't alert for recovery from WARNING status
                 alert = False
+        if current_status == service.ACKED_STATUS:
+            if old_status == service.ACKED_STATUS:
+                # Don't message repeatedly for ACKED status
+                return
+            # Don't @mention when transitioning into the ACKED status
+            alert = False
 
         jenkins_api = urljoin(settings.JENKINS_API, '/')
         c = Context({

--- a/cabot_alert_mattermost/tests/test_mattermost.py
+++ b/cabot_alert_mattermost/tests/test_mattermost.py
@@ -69,8 +69,9 @@ class TestMattermostAlerts(PluginTestCase):
                                      u'**[Service](http://localhost/service/2194/) is reporting ERROR** :sad-panda:\n\n'
                                      u'##### Failing checks\n\n\n\n'
                                      u' @testuser_alias :point_up:\n\n\n'
-                                     u'Someone tell [dolores@affirm.com](http://localhost/user/8/profile/'
-                                     u'MatterMost%20Plugin) to add their MM alias to their profile! :angry:\n',
+                                     u'Someone tell [dolores@affirm.com](http://localhost/user/{}/profile/'
+                                     u'MatterMost%20Plugin) to add their MM alias to their profile! :angry:\n'
+                                     .format(self.duty_officer.pk),
                              'fallback': 'Service is ERROR'
                          }]
                      }
@@ -87,3 +88,19 @@ class TestMattermostAlerts(PluginTestCase):
                                '**[Service](http://localhost/service/2194/) is reporting WARNING** :thinking:\n\n'
                                '##### Failing checks\n', ['testuser_alias']),
         ])
+
+    @patch('cabot_alert_mattermost.models.MatterMostAlert._send_alert')
+    def test_error_to_acked(self, send_alert):
+        self.transition_service(Service.ERROR_STATUS, Service.ACKED_STATUS)
+        send_alert.assert_has_calls([
+            call(self.service, '\n'
+                               '### Service\n'
+                               '**[Service](http://localhost/service/2194/) is reporting ACKED** :zipper_mouth_face:\n'
+                               '\n'
+                               '##### Failing checks\n', ['testuser_alias']),
+        ])
+
+    @patch('cabot_alert_mattermost.models.MatterMostAlert._send_alert')
+    def test_acked_to_acked(self, send_alert):
+        self.transition_service(Service.ACKED_STATUS, Service.ACKED_STATUS)
+        self.assertFalse(send_alert.called)


### PR DESCRIPTION
Adds some basic tests plus some changes to support the 'ACKED' service status.
Acked services will send a message once (on the transition of * -> ACKED), with no @mentions, to make everybody aware that the service has been acked. The service will not send messages again until its status changes.

Requires the 'acks' branch of Cabot for the base testing class.