### PR TITLE
Removed Alerts Between Acked and Passing

### DIFF
--- a/cabot_alert_mattermost/models.py
+++ b/cabot_alert_mattermost/models.py
@@ -278,12 +278,18 @@ class MatterMostAlert(AlertPlugin):
                 # Don't alert repeatedly for ERROR
                 alert = False
         if current_status == service.PASSING_STATUS:
+            if old_status == service.ACKED_STATUS:
+                # Don't message repeatedly for new successes after ACKED failures
+                return
             if old_status == service.WARNING_STATUS:
                 # Don't alert for recovery from WARNING status
                 alert = False
         if current_status == service.ACKED_STATUS:
             if old_status == service.ACKED_STATUS:
                 # Don't message repeatedly for ACKED status
+                return
+            if old_status == service.PASSING_STATUS:
+                # Don't message for acked failures even it started passing
                 return
             # Don't @mention when transitioning into the ACKED status
             alert = False

--- a/cabot_alert_mattermost/tests/test_mattermost.py
+++ b/cabot_alert_mattermost/tests/test_mattermost.py
@@ -109,3 +109,15 @@ class TestMattermostAlerts(PluginTestCase):
     def test_acked_to_acked(self, send_alert):
         self.transition_service_status(Service.ACKED_STATUS, Service.ACKED_STATUS)
         self.assertFalse(send_alert.called)
+
+
+    @patch('cabot_alert_mattermost.models.MatterMostAlert._send_alert')
+    def test_passing_to_acked(self, send_alert):
+        self.transition_service_status(Service.PASSING_STATUS, Service.ACKED_STATUS)
+        self.assertFalse(send_alert.called)
+
+
+    @patch('cabot_alert_mattermost.models.MatterMostAlert._send_alert')
+    def test_acked_to_passing(self, send_alert):
+        self.transition_service_status(Service.ACKED_STATUS, Service.PASSING_STATUS)
+        self.assertFalse(send_alert.called)


### PR DESCRIPTION
This PR removes alerts for transitions between passing and acked statuses. 

Note: getting my env up was a little shakey so have not been able to run tests yet

Background: Servicing encountered a problem with a check that would fail every 15 min, but passing in between failures. When we tried to ack it, our mattermost channel was still filled with alternating alerts that said our check were passing or acked, tagging oncall in the passing alerts. We knew about the issue, and the noise was distracting. 

The only downside I see with this diff, is that if you ack an alert while it is passing, the mattermost channel will not be alerted anymore. While this is undesirable, I think this is fine behavior for now given the difficulty in determining if it the first time we transition into an acked state.