### PR TITLE
Limit to 5 attachments

### DIFF
--- a/cabot_alert_mattermost/models.py
+++ b/cabot_alert_mattermost/models.py
@@ -203,13 +203,13 @@ class MatterMostAlert(AlertPlugin):
         except requests.HTTPError:
             logger.exception('Failed to add users to channel %s. Is the Cabot MM user an admin here?', channel_id)
 
-        failing_checks = service.all_failing_checks()
+        failing_checks = list(service.all_failing_checks())
 
         # Upload images for all failing checks
         file_ids = []
         try:
             files = []
-            for check in failing_checks:
+            for check in failing_checks[:5]:
                 image = check.get_status_image()
                 if image is not None:
                     filename = '{}.png'.format(check.name)


### PR DESCRIPTION
1. The API has a limit of files, after which the POST will fail.
2. Due to a bug in a recent version of Mattermost, if this limit is not respected malformed messages can be posted that break loading certain channels